### PR TITLE
real time streaming directly from webrtc client

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,5 +1,5 @@
 // Client-only entry point for browser usage
 // Exports only the client functionality without server dependencies
-const client = require('./lib/client');
+const IndexCPClient = require('./lib/client');
 
-module.exports = client;
+module.exports = IndexCPClient;

--- a/examples/client-only.js
+++ b/examples/client-only.js
@@ -3,20 +3,37 @@
 // This is ideal for browser environments or when you only need upload capabilities
 
 // Import only the client (no server dependencies loaded)
-const IndexCPClient = require('../client');
+const IndexCPClient = require('../client')
 
 async function clientOnlyExample() {
-  console.log('Client-only example - uploading files...');
-  
-  const client = new IndexCPClient();
-  
+  console.log('Client-only example - uploading files and relaying chunks...');
+  const client = new IndexCPClient({ relayMaxRetries: 3, relayRetryDelay: 1000 });
+
   // Add a file to the buffer
-  await client.addFile('./myfile.txt');
+  await client.addFile('../myfile.txt');
   console.log('File added to buffer');
-  
-  // Upload buffered files to a remote server
-  await client.uploadBufferedFiles('http://localhost:3000/upload');
-  console.log('Files uploaded successfully');
+
+  // Example relay callback: simulate external app
+  async function relayCallback(chunkData, meta) {
+    // Simulate sending chunk to external app (e.g., HTTP, WebSocket, etc.)
+    console.log(`[example relay] Got chunk ${meta.chunkIndex} (${meta.fileName}), id=${meta.id}`);
+    // Simulate confirmation (always true)
+    await new Promise(res => setTimeout(res, 100));
+    return true;
+  }
+
+  // Start relay loop (in background)
+  client.relayChunksInOrder({
+    fileName: '../myfile.txt',
+    onChunk: relayCallback,
+    maxRetries: 3,
+    retryDelay: 1000
+  });
+
+  // Let relay run for a few seconds, then stop
+  setTimeout(() => {
+    client.stopRelay();
+  }, 5000);
 }
 
 // Usage

--- a/examples/relay-media-to-ozwell.js
+++ b/examples/relay-media-to-ozwell.js
@@ -1,0 +1,98 @@
+// relay-media-to-ozwell.js
+//
+// Example: Relay media stream chunks to Ozwell using multipart/form-data POST.
+//
+// Usage:
+//   1. Set OZ_ENDPOINT and (optionally) OZ_API_KEY at the top of this file or via environment variables.
+//   2. Run: node relay-media-to-ozwell.js
+//
+// This script simulates a media stream (Node.js Readable) and demonstrates:
+//   - Buffering the stream into IndexedDB using addStream
+//   - Relaying chunks in order to Ozwell using relayChunksInOrder
+//   - Sending each chunk as multipart/form-data
+//   - Deleting each chunk only after Ozwell confirms receipt
+//   - Handling end-of-stream marker
+
+const IndexCPClient = require('../lib/client');
+const { Readable } = require('stream');
+const FormData = require('form-data');
+const fetch = require('node-fetch');
+
+// === CONFIGURATION ===
+const OZ_ENDPOINT = process.env.OZ_ENDPOINT || 'https://ozwell.example.com/api/upload';
+const OZ_API_KEY = process.env.OZ_API_KEY || '';
+const STREAM_NAME = 'demo-media-stream';
+const SESSION_ID = 'session-123';
+const IS_AUDIO = true; // or false
+const CHUNK_COUNT = 5; // Number of chunks to simulate
+const CHUNK_SIZE = 1024 * 32; // 32KB per chunk
+
+// === Simulate a Node.js Readable media stream ===
+function createSimulatedMediaStream(chunkCount, chunkSize) {
+  let sent = 0;
+  return new Readable({
+    read() {
+      if (sent < chunkCount) {
+        const buf = Buffer.alloc(chunkSize, sent % 256);
+        this.push(buf);
+        sent++;
+      } else {
+        this.push(null); // End of stream
+      }
+    }
+  });
+}
+
+(async () => {
+  const client = new IndexCPClient();
+  const stream = createSimulatedMediaStream(CHUNK_COUNT, CHUNK_SIZE);
+  console.log(`[demo] Buffering simulated media stream: ${STREAM_NAME}, session: ${SESSION_ID}`);
+  await client.addStream(stream, STREAM_NAME, SESSION_ID);
+  console.log('[demo] Stream buffered. Starting relay to Ozwell...');
+
+  // Relay chunks in order to Ozwell
+  await client.relayChunksInOrder({
+    fileName: STREAM_NAME,
+    sessionId: SESSION_ID,
+    onChunk: async (chunk, meta) => {
+      // meta: { id, fileName, chunkIndex, sessionId, isEndMarker }
+      if (meta.isEndMarker) {
+        console.log(`[ozwell] End-of-stream marker for ${meta.fileName} (session: ${meta.sessionId})`);
+        // Optionally notify Ozwell of end-of-stream (customize as needed)
+        return true; // Confirm deletion of end marker
+      }
+      // Construct FormData for this chunk
+      const form = new FormData();
+      form.append('index', meta.chunkIndex);
+      form.append('type', 'media');
+      form.append('sessionId', meta.sessionId);
+      form.append('audio', IS_AUDIO ? 'true' : 'false');
+      form.append('id', meta.id);
+      form.append('data', chunk, {
+        filename: `${meta.fileName}-chunk${meta.chunkIndex}.bin`,
+        contentType: 'application/octet-stream'
+      });
+      // POST to Ozwell
+      try {
+        const res = await fetch(OZ_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            ...form.getHeaders(),
+            ...(OZ_API_KEY ? { 'Authorization': `Bearer ${OZ_API_KEY}` } : {})
+          },
+          body: form
+        });
+        if (!res.ok) {
+          console.error(`[ozwell] Failed to upload chunk ${meta.chunkIndex}: ${res.status} ${res.statusText}`);
+          return false; // Do not delete chunk, will retry
+        }
+        console.log(`[ozwell] Uploaded chunk ${meta.chunkIndex} (${meta.id}) successfully.`);
+        return true; // Confirm deletion
+      } catch (err) {
+        console.error(`[ozwell] Error uploading chunk ${meta.chunkIndex}:`, err.message);
+        return false; // Do not delete chunk, will retry
+      }
+    }
+  });
+  console.log('[demo] Relay to Ozwell complete.');
+})();

--- a/examples/uploadMediaStream.js
+++ b/examples/uploadMediaStream.js
@@ -1,0 +1,83 @@
+/**
+ * Example: Real-Time Chunk Relay with Confirmation-Based Deletion using IndexCPClient
+ *
+ * To run:
+ *   node examples/uploadMediaStream.js
+ *
+ * This demo simulates a media stream by creating a Node.js Readable stream
+ * that emits random data chunks. It buffers the stream using IndexCPClient.addStream,
+ * then demonstrates real-time relay of chunks to an external application (simulated)
+ * using relayChunksInOrder. Each chunk is deleted from the local DB only after
+ * confirmation from the external application, ensuring reliable, low-latency streaming
+ * and efficient storage usage.
+ *
+ * For a real WebRTC stream, replace the simulated stream with the actual media stream’s readable interface.
+ * The external application logic can be replaced with real network calls or IPC as needed.
+ */
+
+const { Readable } = require('stream');
+const IndexCPClient = require('../lib/client');
+
+// Simulate a media stream: emits 100 random 512-byte chunks
+class RandomMediaStream extends Readable {
+  constructor(options = {}) {
+    super(options);
+    this.chunks = options.chunks || 100;
+    this.chunkSize = options.chunkSize || 512;
+    this.sent = 0;
+  }
+  _read() {
+    if (this.sent >= this.chunks) {
+      this.push(null); // end
+      return;
+    }
+    const buf = Buffer.alloc(this.chunkSize);
+    for (let i = 0; i < this.chunkSize; i++) {
+      buf[i] = Math.floor(Math.random() * 256);
+    }
+    this.push(buf);
+    this.sent++;
+  }
+}
+
+async function main() {
+  const client = new IndexCPClient();
+  const sessionId = 'session-' + Date.now();
+  const streamName = 'simulated-media';
+  const mediaStream = new RandomMediaStream({ chunks: 100, chunkSize: 512 });
+
+  console.log(`Buffering simulated media stream as '${streamName}' with sessionId '${sessionId}'...`);
+  const chunkCount = await client.addStream(mediaStream, streamName, sessionId);
+  console.log(`Buffered ${chunkCount} chunks for stream '${streamName}' (session: ${sessionId})`);
+
+  // --- Real-Time Chunk Relay with Confirmation-Based Deletion ---
+  // Simulate an external application relay with async confirmation
+  async function onChunk(chunkData, meta) {
+    // Simulate sending chunk to external app (e.g., network, IPC, etc.)
+    console.log(`[relay-demo] Relaying chunk ${meta.chunkIndex} (id: ${meta.id}) to external app...`);
+    // Simulate async confirmation (e.g., network round-trip)
+    await new Promise(res => setTimeout(res, 50));
+    // Always confirm for demo
+    console.log(`[relay-demo] External app confirmed chunk ${meta.chunkIndex} (id: ${meta.id})`);
+    return true;
+  }
+
+  // Relay options (configurable)
+  const relayOptions = {
+    fileName: streamName,
+    sessionId,
+    onChunk,
+    maxRetries: 5,
+    retryDelay: 200, // ms
+  };
+
+  console.log(`\n[relay-demo] Starting real-time relay for stream '${streamName}' (session: ${sessionId})...`);
+  // Start relay loop (will exit when all chunks relayed and deleted)
+  await client.relayChunksInOrder(relayOptions);
+  console.log(`[relay-demo] All chunks relayed and deleted for stream '${streamName}' (session: ${sessionId})`);
+}
+
+main().catch(err => {
+  console.error('Error in real-time relay demo:', err);
+  process.exit(1);
+});

--- a/lib/client.js
+++ b/lib/client.js
@@ -26,11 +26,304 @@ if (typeof window === 'undefined') {
 }
 
 class IndexCPClient {
-  constructor() {
+  constructor(options = {}) {
     this.db = null;
     this.dbName = 'indexcp';
     this.storeName = 'chunks';
     this.apiKey = null;
+
+    // Configurable options
+    this.uploadInterval = options.uploadInterval || parseInt(process.env.INDEXCP_UPLOAD_INTERVAL) || 10000; // ms
+    this.maxRetries = options.maxRetries || parseInt(process.env.INDEXCP_MAX_RETRIES) || 5;
+    this.baseRetryDelay = options.baseRetryDelay || parseInt(process.env.INDEXCP_BASE_RETRY_DELAY) || 1000; // ms
+    // Local DB chunk storage retry options
+    this.chunkStoreRetries = options.chunkStoreRetries || parseInt(process.env.INDEXCP_CHUNK_STORE_RETRIES) || 2;
+    this.chunkStoreRetryDelay = options.chunkStoreRetryDelay || parseInt(process.env.INDEXCP_CHUNK_STORE_RETRY_DELAY) || 200; // ms
+
+    // Timer state
+    this.uploadTimer = null;
+    this.isUploading = false;
+
+    // Relay state
+    this._relayActive = false;
+    this._relayPromise = null;
+    this._relayStopRequested = false;
+    this.relayMaxRetries = options.relayMaxRetries || 5;
+    this.relayRetryDelay = options.relayRetryDelay || 1000; // ms
+  }
+  /**
+   * Relay chunks in order to an external callback, deleting only after confirmation.
+   * Detects and relays a special end-of-stream marker chunk, notifying the external app.
+   * After relaying the end marker, the relay loop exits gracefully.
+   * @param {Object} options
+   *   - fileName: string (optional, relay only this file/stream)
+   *   - sessionId: string (optional, relay only this session)
+   *   - onChunk: async function(chunk, meta): must resolve true to confirm deletion
+   *   - maxRetries: number (optional)
+   *   - retryDelay: number (optional, ms)
+   */
+  async relayChunksInOrder({ fileName, sessionId, onChunk, maxRetries, retryDelay }) {
+    if (this._relayActive) throw new Error('Relay already running');
+    this._relayActive = true;
+    this._relayStopRequested = false;
+    maxRetries = maxRetries ?? this.relayMaxRetries;
+    retryDelay = retryDelay ?? this.relayRetryDelay;
+    const db = await this.initDB();
+    let relayCompleted = false;
+    while (!this._relayStopRequested && !relayCompleted) {
+      // Get all chunks, filter and sort
+      let allChunks = await db.getAll(this.storeName);
+      if (fileName) allChunks = allChunks.filter(c => c.fileName === fileName);
+      if (sessionId) allChunks = allChunks.filter(c => c.sessionId === sessionId);
+      if (allChunks.length === 0) {
+        await new Promise(res => setTimeout(res, 300));
+        continue;
+      }
+      // Sort: end marker always last (chunkIndex ascending, then isEndMarker)
+      allChunks.sort((a, b) => {
+        if (a.isEndMarker && !b.isEndMarker) return 1;
+        if (!a.isEndMarker && b.isEndMarker) return -1;
+        return a.chunkIndex - b.chunkIndex;
+      });
+      let chunk = allChunks[0];
+      if (!chunk) {
+        await new Promise(res => setTimeout(res, 300));
+        continue;
+      }
+      let attempt = 0;
+      let confirmed = false;
+      // If this is the end marker, notify external app and exit after relay
+      if (chunk.isEndMarker) {
+        while (attempt < maxRetries && !confirmed && !this._relayStopRequested) {
+          try {
+            console.log(`[relay] Relaying END MARKER for ${chunk.fileName} (session: ${chunk.sessionId}) attempt ${attempt+1}`);
+            confirmed = await onChunk(null, {
+              id: chunk.id,
+              fileName: chunk.fileName,
+              chunkIndex: chunk.chunkIndex,
+              sessionId: chunk.sessionId,
+              isEndMarker: true
+            });
+            if (confirmed) {
+              await this.deleteChunkById(chunk.id);
+              console.log(`[relay] Confirmed and deleted END MARKER for ${chunk.fileName} (session: ${chunk.sessionId})`);
+              relayCompleted = true;
+              break;
+            } else {
+              throw new Error('External callback did not confirm end marker');
+            }
+          } catch (err) {
+            attempt++;
+            console.warn(`[relay] Relay failed for END MARKER (${chunk.fileName}), retry ${attempt}/${maxRetries} in ${retryDelay}ms: ${err.message}`);
+            await new Promise(res => setTimeout(res, retryDelay));
+          }
+        }
+        if (!confirmed) {
+          console.error(`[relay] Giving up on END MARKER for ${chunk.fileName} after ${maxRetries} attempts.`);
+          await new Promise(res => setTimeout(res, 500));
+        }
+        // After end marker, exit relay loop
+        break;
+      }
+      // Normal chunk relay
+      while (attempt < maxRetries && !confirmed && !this._relayStopRequested) {
+        try {
+          console.log(`[relay] Relaying chunk ${chunk.chunkIndex} (${chunk.fileName}) attempt ${attempt+1}`);
+          confirmed = await onChunk(chunk.data, {
+            id: chunk.id,
+            fileName: chunk.fileName,
+            chunkIndex: chunk.chunkIndex,
+            sessionId: chunk.sessionId,
+            isEndMarker: false
+          });
+          if (confirmed) {
+            await this.deleteChunkById(chunk.id);
+            console.log(`[relay] Confirmed and deleted chunk ${chunk.chunkIndex} (${chunk.fileName})`);
+          } else {
+            throw new Error('External callback did not confirm');
+          }
+        } catch (err) {
+          attempt++;
+          console.warn(`[relay] Relay failed for chunk ${chunk.chunkIndex} (${chunk.fileName}), retry ${attempt}/${maxRetries} in ${retryDelay}ms: ${err.message}`);
+          await new Promise(res => setTimeout(res, retryDelay));
+        }
+      }
+      if (!confirmed) {
+        console.error(`[relay] Giving up on chunk ${chunk.chunkIndex} (${chunk.fileName}) after ${maxRetries} attempts.`);
+        await new Promise(res => setTimeout(res, 500));
+      }
+    }
+    this._relayActive = false;
+    this._relayStopRequested = false;
+    console.log('[relay] Relay loop stopped.');
+  }
+
+  /**
+   * Stop the relay loop gracefully.
+   */
+  stopRelay() {
+    this._relayStopRequested = true;
+  }
+
+  /**
+   * Delete a single chunk by its ID.
+   */
+  async deleteChunkById(id) {
+    const db = await this.initDB();
+    await db.delete(this.storeName, id);
+    console.log(`[delete] Deleted chunk with id ${id}`);
+  }
+  /**
+   * Buffer an arbitrary readable stream (Node.js or browser) into the DB with sessionId.
+   * @param {ReadableStream|NodeJS.ReadableStream} stream - The readable stream to buffer.
+   * @param {string} streamName - Name/ID for the stream (used as fileName).
+   * @param {string} sessionId - Session identifier for grouping chunks.
+   * @returns {Promise<number>} - Resolves with the number of chunks buffered.
+   */
+  /**
+   * Buffer an arbitrary readable stream (Node.js or browser) into the DB with sessionId.
+   * Adds logging and retry for local DB chunk storage errors.
+   * Appends a special end-of-stream marker chunk to signal stream completion.
+   * The end marker chunk has { isEndMarker: true } and data: null.
+   */
+  async addStream(stream, streamName, sessionId) {
+    const db = await this.initDB();
+    let chunkIndex = 0;
+    let isNodeStream = false;
+    // Detect Node.js stream
+    if (typeof window === 'undefined' && stream && typeof stream.on === 'function') {
+      isNodeStream = true;
+    }
+    // Helper for retrying chunk storage
+    const storeChunkWithRetry = async (chunk, id, fileName, chunkIndex, sessionId, isEndMarker = false) => {
+      let attempt = 0;
+      let lastError = null;
+      while (attempt <= this.chunkStoreRetries) {
+        try {
+          await db.add(this.storeName, {
+            id,
+            fileName,
+            chunkIndex,
+            data: chunk,
+            sessionId,
+            isEndMarker: !!isEndMarker
+          });
+          return;
+        } catch (err) {
+          lastError = err;
+          console.error(`[addStream] Error storing chunk ${chunkIndex} for ${fileName} (session: ${sessionId}), attempt ${attempt + 1}/${this.chunkStoreRetries + 1}: ${err.message}`);
+          if (attempt < this.chunkStoreRetries) {
+            await new Promise(res => setTimeout(res, this.chunkStoreRetryDelay));
+          }
+        }
+        attempt++;
+      }
+      // All retries failed
+      throw new Error(`[addStream] Failed to store chunk ${chunkIndex} for ${fileName} (session: ${sessionId}) after ${this.chunkStoreRetries + 1} attempts: ${lastError && lastError.message}`);
+    };
+    return new Promise((resolve, reject) => {
+      // onChunk now uses retry logic
+      const onChunk = async (chunk) => {
+        const id = `${streamName}-${sessionId}-${chunkIndex}`;
+        try {
+          // Retry logic for chunk storage
+          await storeChunkWithRetry(chunk, id, streamName, chunkIndex, sessionId);
+          if (chunkIndex % 10 === 0) {
+            console.log(`[addStream] Buffered chunk ${chunkIndex} for ${streamName} (session: ${sessionId})`);
+          }
+          chunkIndex++;
+        } catch (err) {
+          // Log and reject if all retries fail
+          console.error(`[addStream] Giving up on chunk ${chunkIndex} for ${streamName} (session: ${sessionId}): ${err.message}`);
+          reject(err);
+        }
+      };
+      const addEndMarker = async () => {
+        // Add a special end marker chunk to the DB
+        const endMarkerId = `${streamName}-${sessionId}-endmarker`;
+        try {
+          await storeChunkWithRetry(null, endMarkerId, streamName, chunkIndex, sessionId, true);
+          console.log(`[addStream] End marker chunk added for ${streamName} (session: ${sessionId}) at chunkIndex ${chunkIndex}`);
+        } catch (err) {
+          console.error(`[addStream] Failed to add end marker for ${streamName} (session: ${sessionId}): ${err.message}`);
+          reject(err);
+        }
+      };
+      if (isNodeStream) {
+        stream.on('data', onChunk);
+        stream.on('end', async () => {
+          await addEndMarker();
+          console.log(`[addStream] Stream ${streamName} (session: ${sessionId}) ended after ${chunkIndex} chunks.`);
+          resolve(chunkIndex);
+        });
+        stream.on('error', reject);
+      } else if (stream && typeof stream.getReader === 'function') {
+        // Browser ReadableStream
+        const reader = stream.getReader();
+        const read = async () => {
+          try {
+            const { value, done } = await reader.read();
+            if (done) {
+              await addEndMarker();
+              console.log(`[addStream] Stream ${streamName} (session: ${sessionId}) ended after ${chunkIndex} chunks.`);
+              resolve(chunkIndex);
+              return;
+            }
+            await onChunk(value);
+            read();
+          } catch (err) {
+            reject(err);
+          }
+        };
+        read();
+      } else {
+        reject(new Error('Unsupported stream type for addStream'));
+      }
+    });
+  }
+  // Timer-based periodic upload
+  startUploadTimer(serverUrl) {
+    if (this.uploadTimer) return;
+    this.uploadTimer = setInterval(() => {
+      if (!this.isUploading) {
+        this.uploadBufferedFiles(serverUrl).catch(err => {
+          console.error('Periodic upload error:', err);
+        });
+      }
+    }, this.uploadInterval);
+    console.log('Upload timer started.');
+  }
+
+  stopUploadTimer() {
+    if (this.uploadTimer) {
+      clearInterval(this.uploadTimer);
+      this.uploadTimer = null;
+      console.log('Upload timer stopped.');
+    }
+  }
+
+  // View upload queue
+  async viewUploadQueue() {
+    const db = await this.initDB();
+    const transaction = db.transaction(this.storeName, 'readonly');
+    const store = transaction.objectStore(this.storeName);
+    const allRecords = await store.getAll();
+    // Group by fileName
+    const fileGroups = {};
+    allRecords.forEach(record => {
+      if (!fileGroups[record.fileName]) fileGroups[record.fileName] = [];
+      fileGroups[record.fileName].push(record.chunkIndex);
+    });
+    return fileGroups;
+  }
+
+  // Clear upload queue
+  async clearUploadQueue() {
+    const db = await this.initDB();
+    const transaction = db.transaction(this.storeName, 'readwrite');
+    const store = transaction.objectStore(this.storeName);
+    await store.clear();
+    console.log('Upload queue cleared.');
   }
 
   async promptForApiKey() {
@@ -76,9 +369,11 @@ class IndexCPClient {
     return this.db;
   }
 
+  /**
+   * Buffer a file into the DB with retry and logging for chunk storage errors.
+   */
   async addFile(filePath) {
     const db = await this.initDB();
-    
     return new Promise((resolve, reject) => {
       const readStream = fs.createReadStream(filePath, { highWaterMark: 1024 * 1024 }); // 1MB chunks
       let chunkIndex = 0;
@@ -87,23 +382,45 @@ class IndexCPClient {
 
       readStream.on('data', (chunk) => {
         chunks.push({
-          id: `${fileName}-${chunkIndex}`, 
+          id: `${fileName}-${chunkIndex}`,
           fileName: fileName,
           chunkIndex: chunkIndex,
-          data: chunk 
+          data: chunk
         });
         chunkIndex++;
       });
 
       readStream.on('end', async () => {
+        // Helper for retrying chunk storage
+        const storeChunkWithRetry = async (chunk, fileName, chunkIndex) => {
+          let attempt = 0;
+          let lastError = null;
+          while (attempt <= this.chunkStoreRetries) {
+            try {
+              await db.add(this.storeName, chunk);
+              return;
+            } catch (err) {
+              lastError = err;
+              console.error(`[addFile] Error storing chunk ${chunkIndex} for ${fileName}, attempt ${attempt + 1}/${this.chunkStoreRetries + 1}: ${err.message}`);
+              if (attempt < this.chunkStoreRetries) {
+                await new Promise(res => setTimeout(res, this.chunkStoreRetryDelay));
+              }
+            }
+            attempt++;
+          }
+          // All retries failed
+          throw new Error(`[addFile] Failed to store chunk ${chunkIndex} for ${fileName} after ${this.chunkStoreRetries + 1} attempts: ${lastError && lastError.message}`);
+        };
         try {
-          // Add all chunks to IndexedDB
+          // Add all chunks to IndexedDB with retry logic
           for (const chunk of chunks) {
-            await db.add(this.storeName, chunk);
+            await storeChunkWithRetry(chunk, fileName, chunk.chunkIndex);
           }
           console.log(`File ${fileName} added to buffer with ${chunkIndex} chunks`);
           resolve(chunkIndex);
         } catch (error) {
+          // Log and reject if all retries fail
+          console.error(`[addFile] Giving up on file ${fileName}: ${error.message}`);
           reject(error);
         }
       });
@@ -113,46 +430,58 @@ class IndexCPClient {
   }
 
   async uploadBufferedFiles(serverUrl) {
+    if (this.isUploading) return;
+    this.isUploading = true;
     const apiKey = await this.getApiKey();
-    
     const db = await this.initDB();
     const transaction = db.transaction(this.storeName, 'readonly');
     const store = transaction.objectStore(this.storeName);
     const allRecords = await store.getAll();
-    
     console.log(`Found ${allRecords.length} buffered chunks`);
-    
     if (allRecords.length === 0) {
-      console.log('No buffered files to upload');
+      console.log('No buffered files or streams to upload');
+      this.isUploading = false;
       return;
     }
-    
     // Group records by fileName
     const fileGroups = {};
     allRecords.forEach(record => {
-      if (!fileGroups[record.fileName]) {
-        fileGroups[record.fileName] = [];
-      }
+      if (!fileGroups[record.fileName]) fileGroups[record.fileName] = [];
       fileGroups[record.fileName].push(record);
     });
-
-    console.log(`Grouped into ${Object.keys(fileGroups).length} files:`, Object.keys(fileGroups));
-
-    // Upload each file's chunks in order
+    console.log(`Grouped into ${Object.keys(fileGroups).length} files/streams:`, Object.keys(fileGroups));
+    // Upload each file/stream's chunks in order
     for (const [fileName, chunks] of Object.entries(fileGroups)) {
       console.log(`Uploading ${fileName} with ${chunks.length} chunks...`);
-      
-      // Sort chunks by index
       chunks.sort((a, b) => a.chunkIndex - b.chunkIndex);
-      
       for (const chunk of chunks) {
-        console.log(`Uploading chunk ${chunk.chunkIndex} for ${fileName}`);
-        await this.uploadChunk(serverUrl, chunk.data, chunk.chunkIndex, fileName, apiKey);
-        await db.delete(this.storeName, chunk.id);
+        let attempt = 0;
+        let success = false;
+        let lastError = null;
+        while (attempt < this.maxRetries && !success) {
+          try {
+            await this.uploadChunk(serverUrl, chunk.data, chunk.chunkIndex, fileName, apiKey);
+            await db.delete(this.storeName, chunk.id);
+            if (attempt > 0) {
+              console.log(`[Retry] Chunk ${chunk.chunkIndex} for ${fileName} uploaded after ${attempt} retries.`);
+            }
+            success = true;
+          } catch (err) {
+            lastError = err;
+            attempt++;
+            if (attempt < this.maxRetries) {
+              const delay = this.baseRetryDelay * Math.pow(2, attempt - 1);
+              console.warn(`[Retry] Upload failed for chunk ${chunk.chunkIndex} (${fileName}), retry ${attempt}/${this.maxRetries} in ${delay}ms:`, err.message);
+              await new Promise(res => setTimeout(res, delay));
+            } else {
+              console.error(`[Retry] Chunk ${chunk.chunkIndex} for ${fileName} failed after ${this.maxRetries} attempts:`, err.message);
+            }
+          }
+        }
       }
-      
       console.log(`Upload complete for ${fileName}`);
     }
+    this.isUploading = false;
   }
 
   async uploadChunk(serverUrl, chunk, index, fileName, apiKey) {

--- a/myfile.txt
+++ b/myfile.txt
@@ -1,1 +1,13 @@
-Test file content
+The data model of a data warehouse is most commonly relational, because SQL is
+generally a good fit for analytic queries. There are many graphical data analysis tools
+that generate SQL queries, visualize the results, and allow analysts to explore the data
+(through operations such as drill-down and slicing and dicing).
+On the surface, a data warehouse and a relational OLTP database look similar,
+because they both have a SQL query interface. However, the internals of the systems
+can look quite different, because they are optimized for very different query patterns.
+Many database vendors now focus on supporting either transaction processing or
+analytics workloads, but not both.
+Some databases, such as Microsoft SQL Server and SAP HANA, have support for
+transaction processing and data warehousing in the same product. However, they are
+increasingly becoming two separate storage and query engines, which happen to be
+accessible through a common SQL interface [49, 50, 51].


### PR DESCRIPTION
The current implementation can read from a file in batches and once a batch upload is complete, it deletes them from db. 
Updates:-
1. Read chunk by chunk from a readable stream(created from mediarecorder)
2. Stream the chunks in the correct order to ozwell concurrently.
3. Delete the individual chunk from db if ozwell confirms the chunk is received.
4. Timer based retry logic for uploading and storing chunks in db.
5. A message indicating that the call ended, so that we can close connections.